### PR TITLE
build: use the built and bundled javascript for main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bolt-ts-custom-function-template",
   "version": "1.0.0",
   "description": "A scaffold template for Slack apps",
-  "main": "app.js",
+  "main": "dist/app.js",
   "scripts": {
     "build": "tsc",
     "start": "npm run build && node ./dist/app.js",


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR updates the `main` in `package.json` to point to the `dist/app.js` that's created after running the following command:

```sh
$ npm run build
```

Fixes an issue of finding the built app with the `@slack/cli-hooks` defaults but does not build the app as part of the `start` hook!

### Notes

This PR matches the changes in https://github.com/slack-samples/bolt-ts-starter-template/pull/133 - will mirror whatever happens here!

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
