### PR TITLE
build: include dependency types when checking types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -90,6 +90,6 @@
         // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
         /* Completeness */
         // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+        "skipLibCheck": false /* Skip type checking all .d.ts files. */
     }
 }


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR sets `skipLibCheck` to **false** so that types of dependencies are checked when running `npm run build`.

This follows experiments of https://github.com/slackapi/bolt-js/pull/2372 to prefer erroring if installed dependencies cause errors in a build 👾 

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
