### PR TITLE
build: comment default typescript option to check types of dependencies

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,7 +69,7 @@
         // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
         "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
         /* Type Checking */
-        "strict": true, /* Enable all strict type-checking options. */
+        "strict": true /* Enable all strict type-checking options. */
         // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
         // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
         // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -90,6 +90,6 @@
         // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
         /* Completeness */
         // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-        "skipLibCheck": false /* Skip type checking all .d.ts files. */
+        // "skipLibCheck": false                             /* Skip type checking all .d.ts files. */
     }
 }


### PR DESCRIPTION
### Type of change

- [x] Documentation

### Summary

This PR comments the default `skipLibCheck` option in `tsconfig.json` to avoid confusion of if this line can be removed without changing compilations 👾

Follows a great [suggestion](https://github.com/slack-samples/bolt-ts-starter-template/pull/141#pullrequestreview-2609828639) of @WilliamBergamin 🧠 ✨ 

### Notes

Reference to `tsc` defaults here! 📚 https://www.typescriptlang.org/docs/handbook/compiler-options.html#handbook-content

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
