### PR TITLE
fix: hide the app home tab in favor of the message tab

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     },
     "features": {
         "app_home": {
-            "home_tab_enabled": true,
+            "home_tab_enabled": false,
             "messages_tab_enabled": true,
             "messages_tab_read_only_enabled": true
         },


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR sets `home_tab_enabled` to false to focus this sample on workflow steps and the messages sent to the messages tab 🤖 

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
