### PR TITLE
fix: change the app name to highlight workflow steps instead of function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Bolt for JavaScript (TypeScript) Custom Function Template
+# Bolt for JavaScript (TypeScript) Custom Step Template
 
-This is a Bolt for JavaScript (TypeScript) template app used to build custom functions for
-use in [Workflow Builder](https://api.slack.com/start#workflow-builder).
+This is a Bolt for JavaScript (TypeScript) template app used to build custom
+steps for use in
+[Workflow Builder](https://api.slack.com/start#workflow-builder).
 
 ## Setup
 
@@ -47,10 +48,10 @@ Before you can run the app, you'll need to store some environment variables.
 
 ```zsh
 # Clone this project onto your machine
-git clone https://github.com/slack-samples/bolt-ts-custom-function-template.git
+git clone https://github.com/slack-samples/bolt-ts-custom-step-template.git
 
 # Change into this project directory
-cd bolt-ts-custom-function-template
+cd bolt-ts-custom-step-template
 
 # Install dependencies
 npm install
@@ -69,7 +70,7 @@ npm test
 
 ## Using Steps in Workflow Builder
 
-With your server running, your function is now ready for use in
+With your server running, your step is now ready for use in
 [Workflow Builder](https://api.slack.com/start#workflow-builder)! Add it as a
 custom step in a new or existing workflow, then run the workflow while your app
 is running.

--- a/app.ts
+++ b/app.ts
@@ -12,25 +12,25 @@ const app = new App({
 });
 
 /** Sample Function Listener */
-app.function('sample_function', async ({ client, inputs, fail, logger }) => {
+app.function('sample_step', async ({ client, inputs, fail, logger }) => {
   try {
     const { user_id } = inputs;
 
     await client.chat.postMessage({
       channel: user_id as string,
-      text: 'Click the button to signal the function has completed',
+      text: 'Click the button to signal the step has completed',
       blocks: [
         {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: 'Click the button to signal the function has completed',
+            text: 'Click the button to signal the step has completed',
           },
           accessory: {
             type: 'button',
             text: {
               type: 'plain_text',
-              text: 'Complete function',
+              text: 'Complete step',
             },
             action_id: 'sample_button',
           },
@@ -39,7 +39,7 @@ app.function('sample_function', async ({ client, inputs, fail, logger }) => {
     });
   } catch (error) {
     logger.error(error);
-    fail({ error: `Failed to handle a function request: ${error}` });
+    fail({ error: `Failed to handle a step request: ${error}` });
   }
 });
 
@@ -48,10 +48,10 @@ app.action<BlockAction>('sample_button', async ({ body, client, complete, fail, 
   const { channel, message, user } = body;
 
   try {
-    // Functions should be marked as successfully completed using `complete` or
+    // Steps should be marked as successfully completed using `complete` or
     // as having failed using `fail`, else they'll remain in an 'In progress' state.
     // Learn more at https://api.slack.com/automation/interactive-messages
-    // biome-ignore lint/style/noNonNullAssertion: we know this button comes from a function, so `fail` is available.
+    // biome-ignore lint/style/noNonNullAssertion: we know this button comes from a step, so `fail` is available.
     await complete!({ outputs: { user_id: user.id } });
 
     await client.chat.update({
@@ -59,12 +59,12 @@ app.action<BlockAction>('sample_button', async ({ body, client, complete, fail, 
       channel: channel!.id,
       // biome-ignore lint/style/noNonNullAssertion: we know this button was posted to a channel, so `message` is available.
       ts: message!.ts,
-      text: 'Function completed successfully!',
+      text: 'Step completed successfully!',
     });
   } catch (error) {
     logger.error(error);
-    // biome-ignore lint/style/noNonNullAssertion: we know this button comes from a function, so `fail` is available.
-    fail!({ error: `Failed to handle a function request: ${error}` });
+    // biome-ignore lint/style/noNonNullAssertion: we know this button comes from a step, so `fail` is available.
+    fail!({ error: `Failed to complete the step: ${error}` });
   }
 });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "display_information": {
-        "name": "Bolt Custom Function"
+        "name": "Bolt Custom Step"
     },
     "features": {
         "app_home": {
@@ -9,7 +9,7 @@
             "messages_tab_read_only_enabled": true
         },
         "bot_user": {
-            "display_name": "Bolt Custom Function",
+            "display_name": "Bolt Custom Step",
             "always_online": false
         }
     },

--- a/manifest.json
+++ b/manifest.json
@@ -35,9 +35,9 @@
         "function_runtime": "remote"
     },
     "functions": {
-        "sample_function": {
-            "title": "Sample function",
-            "description": "Runs sample function",
+        "sample_step": {
+            "title": "Sample step",
+            "description": "Runs sample step",
             "input_parameters": {
                 "user_id": {
                     "type": "slack#/types/user_id",
@@ -52,7 +52,7 @@
                 "user_id": {
                     "type": "slack#/types/user_id",
                     "title": "User",
-                    "description": "User that completed the function",
+                    "description": "User that completed the step",
                     "is_required": true,
                     "name": "user_id"
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bolt-ts-custom-function-template",
+  "name": "bolt-ts-custom-step-template",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bolt-ts-custom-function-template",
+      "name": "bolt-ts-custom-step-template",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bolt-ts-custom-function-template",
+  "name": "bolt-ts-custom-step-template",
   "version": "1.0.0",
-  "description": "A scaffold template for Slack apps",
+  "description": "A custom step template for Slack apps",
   "main": "dist/app.js",
   "scripts": {
     "build": "tsc",
@@ -20,10 +20,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/slack-samples/bolt-ts-custom-function-template.git"
+    "url": "https://github.com/slack-samples/bolt-ts-custom-step-template.git"
   },
   "bugs": {
-    "url": "https://github.com/slack-samples/bolt-ts-custom-function-template/issues"
+    "url": "https://github.com/slack-samples/bolt-ts-custom-step-template/issues"
   },
   "dependencies": {
     "@slack/bolt": "^4.2.1",


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR updates this sample to use the workflow "step" terminologies found in the paired `javascript` sample:

https://github.com/slack-samples/bolt-js-custom-step-template

A few changes hope that with this change the actual `repo` name is changed too? This is left as a follow up change.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
